### PR TITLE
Fix default path to varnish RPM on release_rpm

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,4 +22,4 @@ default['varnish']['VARNISH_STORAGE'] = "malloc" # file | malloc | persistent
 default['varnish']['VARNISH_TTL'] = 120
 default['varnish']['VARNISH_WORKING_DIR'] = ''
 default['varnish']['GeoIP_enabled'] = false
-default['varnish']['release_rpm'] = 'http://repo.varnish-cache.org/redhat/varnish-3.0/el5/noarch/varnish-release-3.0-1.noarch.rpm'
+default['varnish']['release_rpm'] = 'http://repo.varnish-cache.org/redhat/varnish-3.0/el5/noarch/varnish-release/varnish-release-3.0-1.noarch.rpm'


### PR DESCRIPTION
Default release_rpm value was pointing to a non existing path on the repo.varnish-cache.org repository.
This commit updates that value to an existing path.
