### PR TITLE
Fixes issue where 2.x is installed instead of 3.x

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,12 +18,18 @@
 #
 
 
-bash "varnish-cache.org" do
-  user "root"
-  code <<-EOH
-    rpm -q varnish || rpm --nosignature -i #{node['varnish']['release_rpm']}
-  EOH
-  only_if {platform?("redhat", "centos", "fedora", "amazon", "scientific")}
+if platform?("redhat", "centos", "fedora", "amazon", "scientific")
+  bash "varnish-cache.org" do
+    user "root"
+    code <<-EOH
+      rpm -q varnish || rpm --nosignature -i #{node['varnish']['release_rpm']}
+    EOH
+  end
+  ruby_block "Flush yum cache" do
+    block do
+      Chef::Provider::Package::Yum::YumCache.instance.reload
+    end
+  end
 end
 
 if platform?("ubuntu", "debian")
@@ -86,3 +92,4 @@ service "varnishlog" do
   supports :restart => true, :reload => true
   action [ :enable, :start ]
 end
+


### PR DESCRIPTION
When installing a repo out-of-band (i.e. how we do so with bash / rpm here) the internal Chef Yum package cache does not get updated.

This means that if any cookbook executed before this one causes chef to query the availability of varnish packages then the newly added 3.x versions of varnish added by the varnish-release rpm do not show up (and so chef installs the 2.x ones that it cached as available earlier).

The nature of this bug means that moving chef-varnish up the runlist (to before available varnish versions are queried) makes it disappear. It also means that it works if you run vagrant up && vagrant provision as "up" installs the varnish-release rpm thus meaning the second provision run sees the 3.x version in the initial yum query that gets cached.

While the fix is not exactly elegant I've verified that it will hold up to the current Chef 11.8 release.
