### PR TITLE
Added a simple template for use with iptables

### DIFF
--- a/templates/default/port_varnish.erb
+++ b/templates/default/port_varnish.erb
@@ -1,2 +1,2 @@
-# Open the varnish listening port <%= @params[:VARNISH_LISTEN_PORT] %> 
--A FWR -p tcp -m tcp --dport <%= @params[:VARNISH_LISTEN_PORT] %> -j ACCEPT
+# Open the varnish listening port <%= @port %> 
+-A FWR -p tcp -m tcp --dport <%= @port %> -j ACCEPT

--- a/templates/default/port_varnish.erb
+++ b/templates/default/port_varnish.erb
@@ -1,0 +1,2 @@
+# Open the varnish listening port <%= @params[:VARNISH_LISTEN_PORT] %> 
+-A FWR -p tcp -m tcp --dport <%= @params[:VARNISH_LISTEN_PORT] %> -j ACCEPT


### PR DESCRIPTION
This change allows someone to open up an iptables port using the varnish recipe within their recipe:

```ruby
iptables_rule "port_varnish" do
    cookbook  "varnish"
    variables :port => 80
end
```

I was hoping to set it up to use the `VARNISH_LISTEN_PORT` but that was beyond my abilities for the time being. 

