### PR TITLE
Use secure http instead of git protocol

### DIFF
--- a/recipes/geoip.rb
+++ b/recipes/geoip.rb
@@ -17,7 +17,7 @@ if File.exists?("/etc/varnish/geoip.vcl")
 else
 
     git '/usr/src/varnish-geoip' do
-        repository 'git://github.com/svalaskevicius/varnish-geoip.git'
+        repository 'https://github.com/svalaskevicius/varnish-geoip.git'
         reference 'develop'
     end
 


### PR DESCRIPTION
Git protocol requires port 9418 to be open and it's closed on many severs by default.
