### PR TITLE
Add support for DAEMON_OPTS custom parameters

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,3 +23,4 @@ default['varnish']['VARNISH_TTL'] = 120
 default['varnish']['VARNISH_WORKING_DIR'] = ''
 default['varnish']['GeoIP_enabled'] = false
 default['varnish']['release_rpm'] = 'http://repo.varnish-cache.org/redhat/varnish-3.0/el5/noarch/varnish-release/varnish-release-3.0-1.noarch.rpm'
+default['varnish']['custom_parameters'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+require 'shellwords'
 
 if platform?("redhat", "centos", "fedora", "amazon", "scientific")
   bash "varnish-cache.org" do

--- a/templates/default/varnish.erb
+++ b/templates/default/varnish.erb
@@ -110,8 +110,10 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              <% if node['varnish']['GeoIP_enabled'] %>
                  -p 'cc_command=exec cc -fpic -shared -Wl,-x -L/usr/local/lib -lGeoIP -o %o %s' \
              <% end %>
-             -s ${VARNISH_STORAGE}"
-#
+             -s ${VARNISH_STORAGE} \
+             <%= (node['varnish']['custom_parameters'] || []).map { |param_key, param_value|
+                 "-p #{Shellwords.escape(param_key)}=#{Shellwords.escape(param_value)}" }.join(" \\\n") 
+             %>"
 
 
 ## Alternative 4, Do It Yourself. See varnishd(1) for more information.

--- a/templates/ubuntu/varnish.erb
+++ b/templates/ubuntu/varnish.erb
@@ -105,7 +105,10 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
           -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT} \
           -u varnish -g varnish \
           -S ${VARNISH_SECRET_FILE} \
-          -s ${VARNISH_STORAGE}"
+          -s ${VARNISH_STORAGE}" \
+          <%= (node['varnish']['custom_parameters'] || []).map { |param_key, param_value|
+             "-p #{Shellwords.escape(param_key)}=#{Shellwords.escape(param_value)}" }.join(" \\\n") 
+          %>
 
 
 ## Alternative 4, Do It Yourself. See varnishd(1) for more information.


### PR DESCRIPTION
Added support for DAEMON_OPTS custom parameters.

Reasoning for this is adding Magento Turpentine varnish module support, as part of their configuration process requires varnish to be started with multiple custom parameters:
https://github.com/nexcess/magento-turpentine/wiki/Installation
The Turpentine documentation suggests the following params: `-p esi_syntax=0x2` and `-p cli_buffer=16384`.

Example usage (`tools/chef/environments/development.json`):

```json
{
  "name": "development",
  "description": "",
  "json_class": "Chef::Environment",
  "chef_type": "environment",
  "default_attributes": {
      "varnish": {
          "custom_parameters": {
              "esi_syntax": "0x2",
              "cli_buffer": "16384"
          }
      }
  },
  "override_attributes": {}
}
```

Generated `/etc/sysconfig/varnish` (CentOS):

```sh
DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
             -f ${VARNISH_VCL_CONF} \
             -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
             -t ${VARNISH_TTL} \
             -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT} \
             -u varnish -g varnish \
             -S ${VARNISH_SECRET_FILE} \
             -s ${VARNISH_STORAGE}"
             -p esi_syntax=0x2 \
-p cli_buffer=16384
```