### PR TITLE
Add geoip2 support + Fixes for Varnish 4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,13 @@ default['varnish']['custom_parameters'] = {}
 default['varnish']['repository'] = "varnishcache/varnish#{node['varnish']['version'].delete('.')}"
 
 default['varnish']['package_type'] = if platform_family?('rhel', 'fedora', 'suse', 'amazon')
-  'rpm'
-else
-  'deb'
-end
+                                       'rpm'
+                                     else
+                                       'deb'
+                                     end
+
+default['varnish']['VARNISH_SECRET'] = ''
+default['varnish']['VARNISH_SECRET_FILE'] = '/etc/varnish/secret'
+
+default['varnish']['GeoIP2']['enabled'] = false
+default['varnish']['GeoIP2']['database_location'] = '/etc/varnish/geoipdb.mmdb'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,6 @@ default['varnish']['GeoIP_enabled'] = false
 default['varnish']['version'] = '3.0'
 
 default['varnish']['custom_parameters'] = {}
-default['varnish']['repository'] = "varnishcache/varnish#{node['varnish']['version'].delete('.')}"
 
 default['varnish']['package_type'] = if platform_family?('rhel', 'fedora', 'suse', 'amazon')
                                        'rpm'
@@ -36,6 +35,8 @@ default['varnish']['package_type'] = if platform_family?('rhel', 'fedora', 'suse
 
 default['varnish']['VARNISH_SECRET'] = ''
 default['varnish']['VARNISH_SECRET_FILE'] = '/etc/varnish/secret'
+
+default['varnish']['use_varnishlog_service'] = true
 
 default['varnish']['GeoIP2']['enabled'] = false
 default['varnish']['GeoIP2']['database_location'] = '/etc/varnish/geoipdb.mmdb'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ license          'Apache 2.0'
 description      'Installs/Configures chef-varnish'
 name             'chef-varnish'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.1.0'
+version          '2.2.0'
 
 depends 'apt'
 depends 'yum'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,15 +23,12 @@ packagecloud_repo (node['varnish']['repository']).to_s do
   type node['varnish']['package_type']
 end
 
-pkgs = %w( varnish )
-
-pkgs.each do |pkg|
-  package pkg do
-    action :install
-  end
+package 'varnish' do
+  action :install
 end
 
 include_recipe 'chef-varnish::geoip' if node['varnish']['GeoIP_enabled']
+include_recipe 'chef-varnish::geoip2' if node['varnish']['GeoIP2']['enabled']
 
 template "#{node['varnish']['config_dir']}/default.vcl" do
   source 'default.vcl.erb'
@@ -51,6 +48,15 @@ template node['varnish']['daemon_config'] do
   variables(
     params: node['varnish']
   )
+end
+
+file node['varnish']['VARNISH_SECRET_FILE'] do
+  owner 'root'
+  group 'root'
+  mode 0600
+  content node['varnish']['VARNISH_SECRET']
+  only_if { node['varnish']['VARNISH_SECRET'] != '' }
+  notifies :restart, 'service[varnish]', :delayed
 end
 
 service 'varnish' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 
 require 'shellwords'
 
+node.default['varnish']['repository'] = "varnishcache/varnish#{node['varnish']['version'].delete('.')}"
 packagecloud_repo (node['varnish']['repository']).to_s do
   type node['varnish']['package_type']
 end
@@ -67,4 +68,5 @@ end
 service 'varnishlog' do
   supports restart: true, reload: true
   action [:enable, :start]
+  only_if { node['varnish']['use_varnishlog_service'] }
 end

--- a/recipes/geoip2.rb
+++ b/recipes/geoip2.rb
@@ -1,0 +1,72 @@
+if node['varnish']['GeoIP2']['enabled']
+  %w(unzip python-docutils varnish-libs-devel libmaxminddb-devel autoconf automake libtool).each do |pkg|
+    package pkg do
+      action :install
+    end
+  end
+
+  bash 'download libgoip2 varnish module' do
+    code 'wget --no-clobber --no-check-certificate '\
+      '--output-document=/tmp/libvmod-geoip2.zip '\
+      'https://github.com/fgsch/libvmod-geoip2/archive/master.zip'
+    not_if { File.exist? '/tmp/libvmod-geoip2.zip' }
+  end
+
+  bash 'uncompress libgoip2 varnish module' do
+    cwd '/tmp'
+    code 'unzip libvmod-geoip2.zip'
+    not_if { File.directory? '/tmp/libvmod-geoip2-master' }
+  end
+
+  bash 'prepare configuration libgoip2 varnish module' do
+    cwd '/tmp/libvmod-geoip2-master'
+    code './autogen.sh'
+    not_if { File.exist? '/usr/lib64/varnish/vmods/libvmod_geoip2.so' }
+  end
+
+  bash 'configure building libgoip2 varnish module' do
+    cwd '/tmp/libvmod-geoip2-master'
+    code './configure'
+    not_if { File.exist? '/usr/lib64/varnish/vmods/libvmod_geoip2.so' }
+  end
+
+  bash 'build libgoip2 varnish module' do
+    cwd '/tmp/libvmod-geoip2-master'
+    code 'make'
+    not_if { File.exist? '/usr/lib64/varnish/vmods/libvmod_geoip2.so' }
+  end
+
+  bash 'install libgoip2 varnish module' do
+    cwd '/tmp/libvmod-geoip2-master'
+    code 'make install'
+    not_if { File.exist? '/usr/lib64/varnish/vmods/libvmod_geoip2.so' }
+  end
+
+  template "#{node['varnish']['config_dir']}/geoip.vcl" do
+    source 'geoip.vcl.erb'
+    owner 'root'
+    group 'root'
+    mode 0644
+    variables(
+      varnish: node['varnish']
+    )
+    notifies :restart, 'service[varnish]', :delayed
+  end
+
+  bash 'download geoip2 database' do
+    code 'wget --no-clobber --output-document=/tmp/GeoLite2-Country.mmdb.gz http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz'
+    not_if { File.exist? '/tmp/GeoLite2-Country.mmdb.gz' }
+  end
+
+  bash 'uncompress geoip2 database' do
+    cwd '/tmp'
+    code 'rm -f GeoLite2-Country.mmdb && gunzip GeoLite2-Country.mmdb.gz'
+    not_if { File.exist? '/tmp/GeoLite2-Country.mmdb' }
+  end
+
+  bash 'move geoip2 database to the permanent location' do
+    cwd '/tmp'
+    code "mv GeoLite2-Country.mmdb #{node['varnish']['GeoIP2']['database_location']}"
+    not_if { File.directory? '/tmp/GeoLite2-Country.mmdb.gz' }
+  end
+end

--- a/templates/default/default.vcl.erb
+++ b/templates/default/default.vcl.erb
@@ -9,9 +9,13 @@ vcl 4.0;
 include "/etc/varnish/geoip.vcl";
 <% end %>
 
+<% if node['varnish']['GeoIP2']['enabled'] %>
+include "/etc/varnish/geoip2.vcl";
+<% end %>
+
 # Default backend definition.  Set this to point to your content
 # server.
-# 
+#
 backend default {
   .host = "<%= @params[:VARNISH_BACKEND_ADDRESS] %>";
   .port = "<%= @params[:VARNISH_BACKEND_PORT] %>";
@@ -56,7 +60,7 @@ backend default {
 #     }
 #     return (lookup);
 # }
-# 
+#
 # sub vcl_pipe {
 #     # Note that only the first request to the backend will have
 #     # X-Forwarded-For set.  If you use X-Forwarded-For and want to
@@ -66,11 +70,11 @@ backend default {
 #     # applications, like IIS with NTLM authentication.
 #     return (pipe);
 # }
-# 
+#
 # sub vcl_pass {
 #     return (pass);
 # }
-# 
+#
 # sub vcl_hash {
 #     hash_data(req.url);
 #     if (req.http.host) {
@@ -83,15 +87,15 @@ backend default {
 #     <% end %>
 #     return (hash);
 # }
-# 
+#
 # sub vcl_hit {
 #     return (deliver);
 # }
-# 
+#
 # sub vcl_miss {
 #     return (fetch);
 # }
-# 
+#
 # sub vcl_fetch {
 #     if (beresp.ttl <= 0s ||
 #         beresp.http.Set-Cookie ||
@@ -104,11 +108,11 @@ backend default {
 #     }
 #     return (deliver);
 # }
-# 
+#
 # sub vcl_deliver {
 #     return (deliver);
 # }
-# 
+#
 # sub vcl_error {
 #     set obj.http.Content-Type = "text/html; charset=utf-8";
 #     set obj.http.Retry-After = "5";
@@ -132,11 +136,11 @@ backend default {
 # "};
 #     return (deliver);
 # }
-# 
+#
 # sub vcl_init {
 # 	return (ok);
 # }
-# 
+#
 # sub vcl_fini {
 # 	return (ok);
 # }

--- a/templates/default/geoip.vcl.erb
+++ b/templates/default/geoip.vcl.erb
@@ -1,0 +1,13 @@
+import geoip2;
+
+sub geoip_load {
+    new db = geoip2.geoip2("<%= @varnish['GeoIP2']['database_location'] %>");
+}
+
+sub geoip_recv {
+    set req.http.X-Geoip-Country = db.lookup("country/names/en", std.ip(regsub(req.http.X-Forwarded-For, "[, ].*$", ""), client.ip));
+}
+
+sub vcl_init {
+    call geoip_load;
+}


### PR DESCRIPTION
* Add geoip2 support for varnish 4.x
* Allow managing the varnish secret
* Varnish 4.0 wasn't installing (only v3.0) due to being set and read immediately in attributes