### PR TITLE
Fix running under systemd

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES
 
 GRAPH
   apt (2.6.1)
-  chef-varnish (2.0.0)
+  chef-varnish (2.2.1)
     apt (>= 0.0.0)
     packagecloud (~> 0.3.0)
     yum (>= 0.0.0)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,12 @@
-case platform_family
-when 'rhel', 'fedora', 'suse'
-  default['varnish']['daemon_config'] = '/etc/sysconfig/varnish'
-when 'debian'
-  default['varnish']['daemon_config'] = '/etc/default/varnish'
+if (attribute? 'init_package') && node['init_package'] == 'systemd'
+  default['varnish']['daemon_config'] = '/etc/varnish/varnish.params'
+else
+  case platform_family
+  when 'rhel', 'fedora', 'suse'
+    default['varnish']['daemon_config'] = '/etc/sysconfig/varnish'
+  when 'debian'
+    default['varnish']['daemon_config'] = '/etc/default/varnish'
+  end
 end
 
 default['varnish']['config_dir'] = '/etc/varnish'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ license          'Apache 2.0'
 description      'Installs/Configures chef-varnish'
 name             'chef-varnish'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.0'
+version          '2.2.1'
 
 depends 'apt'
 depends 'yum'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -10,7 +10,7 @@ describe 'chef-varnish::default' do
 
     it 'should use the launch parameters in the daemon options' do
       expect(chef_run).to render_file('/etc/sysconfig/varnish')
-        .with_content(match(/-S \${VARNISH_SECRET_FILE} \\\s*-s \${VARNISH_STORAGE}/m))
+        .with_content(match(%r{-S /etc/varnish/secret \\\s*-s\s*malloc,1G}m))
     end
   end
 
@@ -26,7 +26,7 @@ describe 'chef-varnish::default' do
 
     it 'should use the launch parameters in the daemon options' do
       expect(chef_run).to render_file('/etc/sysconfig/varnish')
-        .with_content(match(/-s \${VARNISH_STORAGE} \\\s*-p esi_syntax=0x2 \\\s*-p cli_buffer=16384/m))
+        .with_content(match(%r{-s\s*malloc,1G\s*\\\s*-p esi_syntax=0x2 \\\s*-p cli_buffer=16384}m))
     end
   end
 end

--- a/templates/default/varnish.erb
+++ b/templates/default/varnish.erb
@@ -87,9 +87,9 @@ VARNISH_STORAGE_SIZE=<%= @params[:VARNISH_STORAGE_SIZE] %>
 #
 # # Backend storage specification
 <% if @params[:VARNISH_STORAGE] === "file" %>
-VARNISH_STORAGE="file,${VARNISH_STORAGE_FILE},${VARNISH_STORAGE_SIZE}"
+VARNISH_STORAGE="file,<%= @params[:VARNISH_STORAGE_FILE] %>,<%= @params[:VARNISH_STORAGE_SIZE] %>"
 <% else %>
-VARNISH_STORAGE="malloc,${VARNISH_STORAGE_SIZE}"
+VARNISH_STORAGE="malloc,<%= @params[:VARNISH_STORAGE_SIZE] %>"
 <% end %>
 #
 # # Default TTL used when the backend does not specify one
@@ -97,22 +97,26 @@ VARNISH_TTL=<%= @params[:VARNISH_TTL] %>
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.
-DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
-             -f ${VARNISH_VCL_CONF} \
-             -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
-             -t ${VARNISH_TTL} \
-             -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT} \
+DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:<%= @params[:VARNISH_LISTEN_PORT] %> \
+             -f <%= @params[:VARNISH_VCL_CONF] %> \
+             -T <%= @params[:VARNISH_ADMIN_LISTEN_ADDRESS] %>:<%= @params[:VARNISH_ADMIN_LISTEN_PORT] %> \
+             -t <%= @params[:VARNISH_TTL] %> \
+             -w <%= @params[:VARNISH_MIN_THREADS] %>,<%= @params[:VARNISH_MAX_THREADS] %>,<%= @params[:VARNISH_THREAD_TIMEOUT] %> \
              <% if @params[:VARNISH_UID_SWITCH] %>
              -u varnish -g varnish \
              <% end %>
-             -S ${VARNISH_SECRET_FILE} \
+             -S <%= @params[:VARNISH_SECRET_FILE] %> \
              <% if @params[:VARNISH_WORKING_DIR].to_s != '' %>
                  -n <%= @params[:VARNISH_WORKING_DIR] %> \
              <% end %>
              <% if node['varnish']['GeoIP_enabled'] %>
                  -p 'cc_command=exec cc -fpic -shared -Wl,-x -L/usr/local/lib -lGeoIP -o %o %s' \
              <% end %>
-             -s ${VARNISH_STORAGE} \
+             -s <%- if @params[:VARNISH_STORAGE] === "file" -%>
+                 file,<%= @params[:VARNISH_STORAGE_FILE] %>,<%= @params[:VARNISH_STORAGE_SIZE] %>
+                 <%- else -%>
+                 malloc,<%= @params[:VARNISH_STORAGE_SIZE] %>
+                 <%- end -%> \
              <%= (node['varnish']['custom_parameters'] || []).map { |param_key, param_value|
                  "-p #{Shellwords.escape(param_key)}=#{Shellwords.escape(param_value)}" }.join(" \\\n")
              %>"

--- a/templates/default/varnish.erb
+++ b/templates/default/varnish.erb
@@ -97,7 +97,7 @@ VARNISH_TTL=<%= @params[:VARNISH_TTL] %>
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.
-DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:<%= @params[:VARNISH_LISTEN_PORT] %> \
+DAEMON_OPTS="-a <% if @params[:VARNISH_LISTEN_ADDRESS] %><%= @params[:VARNISH_LISTEN_ADDRESS] %><% end %>:<%= @params[:VARNISH_LISTEN_PORT] %> \
              -f <%= @params[:VARNISH_VCL_CONF] %> \
              -T <%= @params[:VARNISH_ADMIN_LISTEN_ADDRESS] %>:<%= @params[:VARNISH_ADMIN_LISTEN_PORT] %> \
              -t <%= @params[:VARNISH_TTL] %> \
@@ -113,9 +113,9 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:<%= @params[:VARNISH_LISTEN_PORT] %> \
                  -p 'cc_command=exec cc -fpic -shared -Wl,-x -L/usr/local/lib -lGeoIP -o %o %s' \
              <% end %>
              -s <%- if @params[:VARNISH_STORAGE] === "file" -%>
-                 file,<%= @params[:VARNISH_STORAGE_FILE] %>,<%= @params[:VARNISH_STORAGE_SIZE] %>
+                 file,<%= @params[:VARNISH_STORAGE_FILE] %>,<%= @params[:VARNISH_STORAGE_SIZE] -%>
                  <%- else -%>
-                 malloc,<%= @params[:VARNISH_STORAGE_SIZE] %>
+                 malloc,<%= @params[:VARNISH_STORAGE_SIZE] -%>
                  <%- end -%> \
              <%= (node['varnish']['custom_parameters'] || []).map { |param_key, param_value|
                  "-p #{Shellwords.escape(param_key)}=#{Shellwords.escape(param_value)}" }.join(" \\\n")

--- a/templates/default/varnish.erb
+++ b/templates/default/varnish.erb
@@ -101,10 +101,16 @@ DAEMON_OPTS="-a <% if @params[:VARNISH_LISTEN_ADDRESS] %><%= @params[:VARNISH_LI
              -f <%= @params[:VARNISH_VCL_CONF] %> \
              -T <%= @params[:VARNISH_ADMIN_LISTEN_ADDRESS] %>:<%= @params[:VARNISH_ADMIN_LISTEN_PORT] %> \
              -t <%= @params[:VARNISH_TTL] %> \
+             <%- if @params[:version].to_f >= 4.0 -%>
+             -p thread_pool_min=<%= @params[:VARNISH_MIN_THREADS] %> \
+             -p thread_pool_max=<%= @params[:VARNISH_MAX_THREADS] %> \
+             -p thread_pool_timeout=<%= @params[:VARNISH_THREAD_TIMEOUT] %> \
+             <%- else -%>
              -w <%= @params[:VARNISH_MIN_THREADS] %>,<%= @params[:VARNISH_MAX_THREADS] %>,<%= @params[:VARNISH_THREAD_TIMEOUT] %> \
-             <% if @params[:VARNISH_UID_SWITCH] %>
+             <%- end -%>
+             <%- if @params[:VARNISH_UID_SWITCH] -%>
              -u varnish -g varnish \
-             <% end %>
+             <%- end -%>
              -S <%= @params[:VARNISH_SECRET_FILE] %> \
              <% if @params[:VARNISH_WORKING_DIR].to_s != '' %>
                  -n <%= @params[:VARNISH_WORKING_DIR] %> \


### PR DESCRIPTION
Ensure we can run varnish under systemd, as the environment file does not get parsed/interpolated, and is expected to be in /etc/varnish/varnish.params instead of /etc/default/varnish or /etc/sysconfig/varnish.

To keep backwards compatibility, we are not removing any existing declared variables, in case they are used by init scripts somewhere.